### PR TITLE
Added error event propagation for conversion.

### DIFF
--- a/index.js
+++ b/index.js
@@ -452,6 +452,9 @@ at3.downloadSingleURL = (url, outputFile, bitrate) => {
       convert.removeListener('convert-progress', onConvertProgress);
       progressEmitter.emit('end');
     });
+    convert.once('error', (error) => {
+        progressEmitter.emit('error', error);
+    })
   });
 
   dl.once('error', (error) => {


### PR DESCRIPTION
Hello! When ffmpeg-fluent fails for some reason, the resulting error event won't get handled, and an error is thrown. I added an error handler so the download process won't halt as a consequence of this error.

This should almost fix AllToMP3/alltomp3-app#129: with the patch, only the error'd tracks will be skipped.